### PR TITLE
Add pre-requisite of having a destination space

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ CloneSpaceProject.ps1 -SourceOctopusUrl "https://samples.octopus.app" `
     -DestinationSpaceName "Redgate Space" `    
     -ProjectsToClone "all"
 ```
+Note: The destination space should be created before running the clone scripts. 
 
 # Use cases
 


### PR DESCRIPTION
When I followed the instructions ran into this missing space error: 

`Exception: /Users/mudra/code/SpaceCloner/src/DataAccess/OctopusRepository.ps1:218
Line |
 218 |              Throw "Unable to find space $spaceName on $octopusUrl ple …
     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Unable to find space TestSpace on https://quality-coach-interview.testoctopus.app/ please confirm it exists and try again.`

Hence adding a note to create space before running the script. 