### PR TITLE
Remove redundant slash that causes errors.

### DIFF
--- a/src/DataAccess/OctopusDataAdapter.ps1
+++ b/src/DataAccess/OctopusDataAdapter.ps1
@@ -13,7 +13,7 @@ function Get-OctopusUrl
             $EndPoint = $EndPoint.Substring($EndPoint.IndexOf("/api"))
         }
 
-        return "$OctopusUrl/$EndPoint"
+        return "$OctopusUrl$EndPoint"
     }
 
     if ([string]::IsNullOrWhiteSpace($SpaceId))


### PR DESCRIPTION
When running this against our instance of Octopus we received this error in the logs:

> The channel Default already exists for project [Project Name].  Skipping it.
Finished clone of project channels
No data to post or put, calling bog standard invoke-restmethod for https://[client].octopus.app/api/Spaces-2/projects/Projects-281/channels
https://[client].octopus.app/api/Spaces-2/projects/Projects-281/channels returned a list with 1 item(s)
Syncing deployment process for [Project Name]
No data to post or put, calling bog standard invoke-restmethod for https://[client].octopus.app//api/Spaces-1/deploymentprocesses/deploymentprocess-Projects-101
Error calling https://[client].octopus.app//api/Spaces-1/deploymentprocesses/deploymentprocess-Projects-101 The remote server returned an error: (404) Not Found. StatusCode: 404 StatusDescription: Not Found {
  "ErrorMessage": "The resource you requested was not found."
}

Upon further review, the failure is in the double slash for API. This occurs because the Project request returns a links element with the DeploymentProcess value beginning with a leading slash and the method is effectively requiring the leading slash just to enter that evaluation.

By removing the the extra slash in the result, our script continued without issue or error.

**Note**: I'm not familiar enough with versions of Powershell to be positive this change will allow backwards compatibility since I've only recently started using it.