### PR TITLE
Fix empty value check

### DIFF
--- a/src/Core/Util.ps1
+++ b/src/Core/Util.ps1
@@ -659,12 +659,14 @@ function Test-OctopusScopeMatchParameter
         $singleValueItem
     )
 
-    $lowerParameterValue = $parameterValue.ToLower().Trim()
-
+    
     if ([string]::IsNullOrWhiteSpace($parameterValue))
     {
         return $defaultValue
     }
+
+    $lowerParameterValue = $parameterValue.ToLower().Trim()
+
 
     if ($singleValueItem)
     {


### PR DESCRIPTION
Can't convert an object if it's a null value.   Move to after the default which checks if value is default or not. 

Should fix ticket #19