### PR TITLE
Update CloneTentacleInstance.ps1

### DIFF
--- a/CloneTentacleInstance.ps1
+++ b/CloneTentacleInstance.ps1
@@ -109,7 +109,7 @@ function Compare-TentacleWithMachineRegistration
         return $true
     }
 
-    $portNumber = ($machineRegistration.EndPoint.Uri -split ":")[2]    
+    $portNumber = ([System.Uri]$machineRegistration.EndPoint.Uri).Port
     if ($localTentacle.Tentacle.Services.PortNumber -eq $portNumber)
     {
         Write-OctopusSuccess "The machine $($machineRegistration.Id):$($machineRegistration.Name) port $($localTentacle.Tentacle.Services.PortNumber) matches port number $portNumber"


### PR DESCRIPTION
Changed $portNumber value to use `System.Uri`. This will allow it to account for trailing slashes in the `Endpoint.Uri` coming from the Octopus API and prevent inequality evaluations on line 113.